### PR TITLE
Fix pyjson5 and scipy dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gym==0.21.0
 gym3==0.3.3
 rlgym==1.1.0
 pyjson5==1.6.1
-matplotlib==3.1.1
+matplotlib>=3.1, <4
 -e git+https://github.com/kenjyoung/MinAtar.git@2a12fc8af0402f7473c567b2d74f7236b2551681#egg=MinAtar
 msgpack==1.0.2
 msgpack-numpy==0.4.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ absl-py==0.7.1
 gym==0.21.0
 gym3==0.3.3
 rlgym==1.1.0
-pyjson5==0.9.8
+pyjson5==1.6.1
 matplotlib==3.1.1
 -e git+https://github.com/kenjyoung/MinAtar.git@2a12fc8af0402f7473c567b2d74f7236b2551681#egg=MinAtar
 msgpack==1.0.2
@@ -14,10 +14,11 @@ pywin32==228
 redis==3.5.3
 rlgym==1.1.0
 rlgym-tools @ git+https://github.com/RLGym/rlgym-tools.git@8657b86590813e7f2644af6113218f9133bfda5c
-scipy==1.3.0
+scipy>=1.8.0, <2.0.0
 stable_baselines3
 
 --find-links https://download.pytorch.org/whl/torch_stable.html
+# torch==1.11.0+cpu # CPU only version (smaller, no gpu acceleration)
 torch==1.11.0
 torchvision==0.12.0
 


### PR DESCRIPTION
pyjson5 was set to version 0.9.8, presumably for this repository: https://github.com/dpranke/pyjson5/tags
However `pyjson5` on [Pypi](https://pypi.org/project/pyjson5/) actually goes to https://github.com/Kijewski/pyjson5/releases/tag/v1.6.1. Version bumped to v1.6.1

Scipy 1.3.0 is old and it wasn't even available for me to install on Windows in Python 3.9, https://pypi.org/project/scipy/1.3.0/. Version bumped to 1.8.0

matplotlib 3.1.1 doesn't have wheels for Python 3.9, I felt that the version was overly specific and opened the version up to allow pip to select the version that has wheels available for your Python version.

Added comment for cpu installation of torch, for folks like me that don't have GPUs, does not affect installation.