### PR TITLE
Declarative config for Rocket League env, and make it possible to pass experiment config via positional CLI arg

### DIFF
--- a/Environments/Custom/RocketLeague/ActionParserFactory.py
+++ b/Environments/Custom/RocketLeague/ActionParserFactory.py
@@ -1,0 +1,19 @@
+from rlgym.utils.action_parsers import ContinuousAction, DefaultAction, DiscreteAction
+from rlgym_tools.extra_action_parsers.kbm_act import KBMAction
+
+from Environments.Custom.RocketLeague.FactoryBuilder import build_component_factory
+
+_builders = {
+    "continuous": ContinuousAction,
+    "default": DefaultAction,
+    "discrete": DiscreteAction,
+    "kbm": KBMAction
+}
+
+_arg_transformers = {}
+
+register_action_parser, build_action_parser_from_config = build_component_factory(
+    component_name="action parser",
+    builders=_builders,
+    arg_transformers=_arg_transformers
+)

--- a/Environments/Custom/RocketLeague/FactoryBuilder.py
+++ b/Environments/Custom/RocketLeague/FactoryBuilder.py
@@ -1,0 +1,44 @@
+def build_component_factory(component_name, builders, arg_transformers, require_list=False, optional=False):
+
+    def register(key, builder, args_transformer = None):
+        builders[key] = builder
+        if args_transformer:
+            arg_transformers[key] = args_transformer
+
+    def build(config):
+        if not optional and ((not config) or len(config) == 0):
+            raise AttributeError(f"{component_name} is not optional")
+
+        if require_list and type(config) != list:
+            raise AttributeError(f"{component_name} must be list of {component_name}s")
+        
+        if type(config) == str:
+            return build_individual({ config: {} })
+
+        if type(config) == list or len(config) > 1:
+            if type(config) == dict:
+                return [build_individual({ key: config[key] } for key in config)]
+
+            return [ build_individual(c) for c in config ]
+
+        elif len(config) == 1:
+            return build_individual(config)
+
+        return None
+
+    def build_individual(config):
+        key = config.keys()[0]
+
+        Builder = builders.get(key, None)
+
+        if not Builder:
+            raise AttributeError(f"No {component_name} found for key '{key}'")
+
+        kwargs = config[key]
+
+        if key in arg_transformers:
+            kwargs = arg_transformers(**kwargs)
+
+        return Builder(**kwargs)
+    
+    return register, build

--- a/Environments/Custom/RocketLeague/ObsBuilderFactory.py
+++ b/Environments/Custom/RocketLeague/ObsBuilderFactory.py
@@ -1,0 +1,28 @@
+from rlgym.utils.obs_builders import AdvancedObs, DefaultObs
+from rlgym_tools.extra_obs.advanced_padder import AdvancedObsPadder
+from rlgym_tools.extra_obs.advanced_stacker import AdvancedStacker
+from rlgym_tools.extra_obs.general_stacking import GeneralStacker
+
+from Environments.Custom.RocketLeague.FactoryBuilder import build_component_factory
+
+_builders = {
+    "default": DefaultObs,
+    "advanced": AdvancedObs,
+    "advanced_stacker": AdvancedStacker,
+    "advanced_padder": AdvancedObsPadder,
+    "general_stacker": GeneralStacker
+}
+
+_arg_transformers = { 
+    "general_stacker": lambda **kwargs: {
+        "obs": build_obs_builder_from_config(kwargs), 
+        "stack_size": kwargs.get("stack_size", 15)
+    }
+}
+
+
+register_obs_builder, build_obs_builder_from_config = build_component_factory(
+    component_name="obs builder",
+    builders=_builders,
+    arg_transformers=_arg_transformers
+)

--- a/Environments/Custom/RocketLeague/RLGymFactory.py
+++ b/Environments/Custom/RocketLeague/RLGymFactory.py
@@ -5,6 +5,11 @@ from rlgym.utils.action_parsers import DiscreteAction
 from rlgym.utils.obs_builders import DefaultObs
 from rlgym.utils.reward_functions import DefaultReward
 from rlgym.utils.state_setters import DefaultState
+from Environments.Custom.RocketLeague.ActionParserFactory import build_action_parser_from_config
+from Environments.Custom.RocketLeague.ObsBuilderFactory import build_obs_builder_from_config
+from Environments.Custom.RocketLeague.RewardFunctionFactory import build_reward_fn_from_config
+from Environments.Custom.RocketLeague.StateSetterFactory import build_state_setter_from_config
+from Environments.Custom.RocketLeague.TerminalConditionsFactory import build_terminal_conditions_from_config
 
 
 def build_rlgym_from_config(config):
@@ -16,28 +21,40 @@ def build_rlgym_from_config(config):
     reward_fn = DefaultReward()
     terminal_conditions = [TimeoutCondition(225), GoalScoredCondition()]
 
-    env_id = int(cfg["env_id"])
+    if cfg.get("env_id", None):
+        env_id = int(cfg["env_id"])
 
-    if env_id == 0:
-        action_parser = Default.DefaultActionParser()
-        obs_builder = Default.DefaultObsBuilder()
-        state_setter = Default.DefaultStateSetter()
-        reward_fn = Default.DefaultRewardFunction()
-        terminal_conditions = [Default.DefaultTerminalConditions()]
+        if env_id == 0:
+            action_parser = Default.DefaultActionParser()
+            obs_builder = Default.DefaultObsBuilder()
+            state_setter = Default.DefaultStateSetter()
+            reward_fn = Default.DefaultRewardFunction()
+            terminal_conditions = [Default.DefaultTerminalConditions()]
 
-    elif env_id == 1:
-        action_parser = SoloDefender.SoloDefenderActionParser()
-        obs_builder = SoloDefender.SoloDefenderObsBuilder()
-        state_setter = SoloDefender.SoloDefenderStateSetter()
-        reward_fn = SoloDefender.SoloDefenderRewardFunction()
-        terminal_conditions = [SoloDefender.SoloDefenderTerminalConditions()]
-    
-    elif env_id == 2:
-        action_parser = Kickoff.NectoActionParser()
-        obs_builder = Kickoff.KickoffObsBuilder()
-        state_setter = Kickoff.KickoffStateSetter()
-        reward_fn = Kickoff.KickoffRewardFunction()
-        terminal_conditions = [Kickoff.KickoffTerminalConditions()]
+        elif env_id == 1:
+            action_parser = SoloDefender.SoloDefenderActionParser()
+            obs_builder = SoloDefender.SoloDefenderObsBuilder()
+            state_setter = SoloDefender.SoloDefenderStateSetter()
+            reward_fn = SoloDefender.SoloDefenderRewardFunction()
+            terminal_conditions = [SoloDefender.SoloDefenderTerminalConditions()]
+        
+        elif env_id == 2:
+            action_parser = Kickoff.NectoActionParser()
+            obs_builder = Kickoff.KickoffObsBuilder()
+            state_setter = Kickoff.KickoffStateSetter()
+            reward_fn = Kickoff.KickoffRewardFunction()
+            terminal_conditions = [Kickoff.KickoffTerminalConditions()]
+
+    if cfg["action_parser"]:
+        action_parser = build_action_parser_from_config(cfg["action_parser"])
+    if cfg["obs"]:
+        obs_builder = build_obs_builder_from_config(cfg["obs"])
+    if cfg["state_setters"]:
+        state_setter = build_state_setter_from_config(cfg["state_setters"])
+    if cfg["reward_fn"]:
+        reward_fn = build_reward_fn_from_config(cfg["reward_fn"])
+    if cfg["terminal_conditions"]:
+        terminal_conditions = build_terminal_conditions_from_config(cfg["terminal_conditions"])
 
     return rlgym.make(
         game_speed=cfg["game_speed"],

--- a/Environments/Custom/RocketLeague/RewardFunctionFactory.py
+++ b/Environments/Custom/RocketLeague/RewardFunctionFactory.py
@@ -1,0 +1,80 @@
+from types import NoneType
+from typing import Any, Callable, Dict, Union, Str
+from rlgym.utils.reward_functions.combined_reward import CombinedReward
+from rlgym.utils.reward_functions.common_rewards import AlignBallGoal, \
+        BallYCoordinateReward, ConstantReward, EventReward, FaceBallReward, \
+        LiuDistanceBallToGoalReward, LiuDistancePlayerToBallReward, \
+        RewardIfBehindBall, RewardIfClosestToBall, RewardIfTouchedLast, \
+        SaveBoostReward, TouchBallReward, VelocityBallToGoalReward, \
+        VelocityPlayerToBallReward
+
+from rlgym_tools.extra_rewards.anneal_rewards import AnnealRewards
+from rlgym_tools.extra_rewards.diff_reward import DiffReward
+from rlgym_tools.extra_rewards.distribute_rewards import DistributeRewards
+from rlgym_tools.extra_rewards.jump_touch_reward import JumpTouchReward
+from rlgym_tools.extra_rewards.kickoff_reward import KickoffReward
+from rlgym_tools.extra_rewards.multi_model_rewards import MultiModelReward
+from rlgym_tools.extra_rewards.multiply_rewards import MultiplyRewards
+from rlgym_tools.extra_rewards.sequential_rewards import SequentialRewards
+
+from Environments.Custom.RocketLeague.ComponentBuilderFactory import build_component_builder_factory
+
+_builders = {
+    "combined": CombinedReward,
+    "align_ball_goal": AlignBallGoal,
+    "ball_y_coordinate": BallYCoordinateReward,
+    "constant": ConstantReward,
+    "event": EventReward,
+    "face_ball": FaceBallReward,
+    "liu_distance_ball_to_goal": LiuDistanceBallToGoalReward,
+    "liu_distance_player_to_ball": LiuDistancePlayerToBallReward,
+    "save_boost": SaveBoostReward,
+    "touch_ball": TouchBallReward,
+    "if_behind_ball": RewardIfBehindBall,
+    "if_closest_to_ball": RewardIfClosestToBall,
+    "if_touched_last": RewardIfTouchedLast,
+    "velocity_ball_to_goal": VelocityBallToGoalReward,
+    "velocity_player_to_ball": VelocityPlayerToBallReward,
+    "anneal_rewards": lambda **kwargs: AnnealRewards(*sum(zip([build_reward_fn_from_config(r) for r in kwargs["reward_functions"]], kwargs["weights"]), ())),
+    "diff": DiffReward,
+    "distribute": DistributeRewards,
+    "jump_touch": JumpTouchReward,
+    "kickoff": KickoffReward,
+    "multi_model": MultiModelReward,
+    "multiply": MultiplyRewards,
+    "sequential": SequentialRewards
+}
+
+_arg_transformers = {
+    "combined": lambda **kwargs: {
+        "rewards": build_reward_fn_from_config(kwargs["reward_functions"]),
+        "weights": tuple(kwargs["reward_weights"])
+    },
+    "diff": lambda **kwargs: {
+        "reward": build_reward_fn_from_config(kwargs["reward_function"]),
+        "negative_slope": kwargs.get("negative_slope", 0.1)
+    },
+    "distribute": lambda **kwargs: {
+        "reward": build_reward_fn_from_config(kwargs["reward_function"]),
+        "team_spirit": kwargs.get("team_spirit", 0.3)
+    },
+    "multi_model": lambda **kwargs: {
+        "rewards": build_reward_fn_from_config(kwargs["reward_funcs"]),
+        "model_map": kwargs["model_map"],
+    },
+    "multiply": lambda **kwargs: {
+        "rewards": [build_reward_fn_from_config(f) for f in kwargs["reward_functions"]]
+    },
+    "sequential": lambda **kwargs: {
+        "rewards": [build_reward_fn_from_config(f) for f in kwargs["rewards"]],
+        "steps": kwargs["steps"]
+    },
+}
+
+
+register_reward_function, build_reward_fn_from_config = build_component_builder_factory(
+    "reward function",
+    builders=_builders,
+    arg_transformers=_arg_transformers,
+    optional=False
+)

--- a/Environments/Custom/RocketLeague/StateSetterFactory.py
+++ b/Environments/Custom/RocketLeague/StateSetterFactory.py
@@ -1,0 +1,41 @@
+from rlgym.utils.state_setters import DefaultState, RandomState
+from rlgym_tools.extra_state_setters.augment_setter import AugmentSetter
+from rlgym_tools.extra_state_setters.goalie_state import GoaliePracticeState
+from rlgym_tools.extra_state_setters.hoops_setter import HoopsLikeSetter
+from rlgym_tools.extra_state_setters.replay_setter import ReplaySetter
+from rlgym_tools.extra_state_setters.wall_state import WallPracticeState
+from rlgym_tools.extra_state_setters.symmetric_setter import KickoffLikeSetter
+from rlgym_tools.extra_state_setters.weighted_sample_setter import WeightedSampleSetter
+
+from Environments.Custom.RocketLeague.FactoryBuilder import build_component_factory
+
+_builders = {
+    "default": DefaultState,
+    "kickoff": DefaultState,
+    "random": RandomState,
+    "augment_setter": AugmentSetter,
+    "goalie": GoaliePracticeState,
+    "hoops": HoopsLikeSetter,
+    "replay": ReplaySetter,
+    "wall": WallPracticeState,
+    "kickoff_like": KickoffLikeSetter,
+    "weighted_sample": WeightedSampleSetter
+}
+
+_arg_transformers = {
+    "augment_setter": lambda **kwargs: {
+        "state_setter": build_state_setter_from_config(kwargs["state_setter"]),
+        "shuffle_within_teams": kwargs.get("shuffle_within_teams", True),
+        "swap_front_back": kwargs.get("swap_front_back", True)
+    },
+    "weighted_sample": lambda **kwargs: {
+        "state_setters": [build_state_setter_from_config(s) for s in kwargs["state_setters"]],
+        "weights": kwargs["weights"]
+    }
+}
+
+register_state_setter, build_state_setter_from_config = build_component_factory(
+    component_name ="state setter",
+    builders = _builders,
+    arg_transformers=_arg_transformers
+)

--- a/Environments/Custom/RocketLeague/TerminalConditionsFactory.py
+++ b/Environments/Custom/RocketLeague/TerminalConditionsFactory.py
@@ -1,0 +1,22 @@
+from rlgym.utils.terminal_conditions.common_conditions import BallTouchedCondition, GoalScoredCondition, NoTouchTimeoutCondition, TimeoutCondition
+from rlgym_tools.extra_terminals.game_condition import GameCondition
+
+from Environments.Custom.RocketLeague.FactoryBuilder import build_component_factory
+
+
+_builders = {
+    "ball_touched": BallTouchedCondition,
+    "goal_scored": GoalScoredCondition,
+    "no_touch_timeout": NoTouchTimeoutCondition,
+    "timeout": TimeoutCondition,
+    "game": GameCondition
+}
+
+_arg_transformers = {}
+
+register_terminal_condition, build_terminal_conditions_from_config = build_component_factory(
+    component_name = "terminal condition",
+    builders = _builders,
+    arg_transformers = _arg_transformers,
+    require_list=True
+)

--- a/Run_Server.py
+++ b/Run_Server.py
@@ -1,3 +1,4 @@
+import os,sys
 import random
 random.seed(0)
 import numpy as np
@@ -9,10 +10,13 @@ from PolicyOptimization.DistribPolicyGradients import Server
 from Experiments import ExperimentManager
 import traceback
 
-
 def main():
-    # experiment_path = "resources/experiments/test_experiments/basic_test_experiment.json"
-    experiment_path = "resources/experiments/test_experiments/rocket_league_test_experiment.json"
+    if len(sys.argv) == 1:
+        experiment_path = "resources/experiments/test_experiments/walker2d_config.json"
+    if len(sys.argv) == 2:
+        experiment_path = sys.argv[1]
+        if not os.path.exists(experiment_path):
+            raise FileNotFoundError(f"No experiment file found at location '{experiment_path}'")
 
     server = Server()
     experiment_manager = ExperimentManager(server)


### PR DESCRIPTION
Should be backward compatible with existing experiments (I didn't remove the `env_id` stuff, just made it possible to specify the items that `env_id` defines from w/i the experiment JSON).