### PR TITLE
Avoid multiprocessing.Queue.qsize() in MPFramework

### DIFF
--- a/distrib_rl/MPFramework/MPFResultPublisher.py
+++ b/distrib_rl/MPFramework/MPFResultPublisher.py
@@ -39,4 +39,4 @@ class MPFResultPublisher(object):
         del data
 
     def is_empty(self):
-        return self._output_queue.qsize() == 0
+        return self._output_queue.empty()

--- a/distrib_rl/MPFramework/MPFTaskChecker.py
+++ b/distrib_rl/MPFramework/MPFTaskChecker.py
@@ -115,7 +115,7 @@ class MPFTaskChecker(object):
             try:
                 fail_count = 0
                 # This is a copy and paste of get_all() from MPFProcessHandler.
-                while self._input_queue.qsize() > 0:
+                while not self._input_queue.empty():
                     try:
                         result = self._input_queue.get(block=True, timeout=0.1)
 


### PR DESCRIPTION
The `qsize` method on `multiprocessing.Queue` throws a
`NotImplementedError` on various flavors of unix, including macOS.
Avoiding the use of this method is the only logic change necessary for
distrib-rl to run well on these systems.