### PR TITLE
Upgrade to pytorch v1.12.2, remove unused dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,8 @@ redis==3.5.3
 scipy>=1.8.0, <2.0.0
 
 --find-links https://download.pytorch.org/whl/torch_stable.html
-# torch==1.11.0+cpu # CPU only version (smaller, no gpu acceleration)
-torch==1.11.0
-torchvision==0.12.0
+# torch==1.12.1+cpu # CPU only version (smaller, no gpu acceleration)
+torch==1.12.1
 
 trueskill==0.4.5
 wandb==0.13.1

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ setup(
         'psutil==5.8.0',
         'redis==3.5.3',
         'scipy>=1.8.0, <2.0.0',
-        'torch==1.11.0',
-        'torchvision==0.12.0',
+        'torch==1.12.1',
         'trueskill==0.4.5',
         'wandb==0.13.1'
     ],


### PR DESCRIPTION
v1.12.2 adds support for running tensor calculations on Apple M1 GPUs
via Apple's metal API. To use this, set the torch device to "mps".

There are a few minor breaking changes that took effect since v1.12.0
that should not affect distrib-rl, however the release notes describing
these can be found here:
https://github.com/pytorch/pytorch/releases/tag/v1.12.0